### PR TITLE
Hosting SiteConfig

### DIFF
--- a/mmv1/products/firebasehosting/api.yaml
+++ b/mmv1/products/firebasehosting/api.yaml
@@ -65,3 +65,36 @@ objects:
         name: defaultUrl
         output: true
         description: The default URL for the site in the form of https://{name}.web.app
+  - !ruby/object:Api::Resource
+    name: 'SiteConfig'
+    min_version: beta
+    base_url: projects/{{project}}/sites/{{site_id}}
+    self_link: sites/{{site_id}}/config
+    create_url: sites/{{site_id}}/config?update_mask=maxVersions,cloudLoggingEnabled # SiteConfig is created as part of Site creation, treat as an update
+    create_verb: :PATCH
+    update_verb: :PATCH
+    update_mask: true
+    description: | 
+      A `SiteConfig` contains metadata associated with a specific site that
+      controls Firebase Hosting serving behavior
+    parameters:
+      - !ruby/object:Api::Type::String
+        name: site_id
+        description: |
+          Required. Immutable. A globally unique identifier for the Hosting site. This identifier is
+          used to construct the Firebase-provisioned subdomains for the site, so it must also be a valid
+          domain name label.
+        input: true
+        url_param_only: true
+    properties:
+      - !ruby/object:Api::Type::Integer
+        name: maxVersions
+        description: |
+          The number of FINALIZED versions that will be held for a site before automatic deletion. When a new
+          version is deployed, content for versions in storage in excess of this number will be deleted, and
+          will no longer be billed for storage usage. Oldest versions will be deleted first; Default is 100
+        default_value: 100
+      - !ruby/object:Api::Type::Boolean
+        name: cloudLoggingEnabled
+        description: |
+          Whether or not web requests made by site visitors are logged via Cloud Logging.

--- a/mmv1/products/firebasehosting/terraform.yaml
+++ b/mmv1/products/firebasehosting/terraform.yaml
@@ -32,6 +32,27 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           site_id: site-with-app
         test_env_vars:
           project_id: :PROJECT_NAME
+  SiteConfig: !ruby/object:Overrides::Terraform::ResourceOverride
+    import_format: ['projects/{{project}}/sites/{{site_id}}/config', 'sites/{{site_id}}/config', '{{site_id}}/config']
+    skip_delete: true # SiteConfig is a singleton child of Site
+    skip_sweeper: true # no sweeper
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "firebasehosting_siteconfig_basic"
+        min_version: "beta"
+        primary_resource_id: "default"
+        vars:
+          site_id: site-config
+        test_env_vars:
+          project_id: :PROJECT_NAME
+      - !ruby/object:Provider::Terraform::Examples
+        name: "firebasehosting_siteconfig_full"
+        min_version: "beta"
+        primary_resource_id: "full"
+        vars:
+          site_id: site-config-full
+        test_env_vars:
+          project_id: :PROJECT_NAME
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files
   # These files have templating (ERB) code that will be run.

--- a/mmv1/templates/terraform/examples/firebasehosting_siteconfig_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/firebasehosting_siteconfig_basic.tf.erb
@@ -1,0 +1,13 @@
+resource "google_firebase_hosting_site" "default" {
+  provider = google-beta
+  project  = "<%= ctx[:test_env_vars]['project_id'] %>"
+  site_id = "<%= ctx[:vars]['site_id'] %>"
+}
+
+resource "google_firebase_hosting_site_config" "default" {
+  provider = google-beta
+  project  = "<%= ctx[:test_env_vars]['project_id'] %>"
+  site_id = "<%= ctx[:vars]['site_id'] %>"
+
+  depends_on = [google_firebase_hosting_site.default]
+}

--- a/mmv1/templates/terraform/examples/firebasehosting_siteconfig_full.tf.erb
+++ b/mmv1/templates/terraform/examples/firebasehosting_siteconfig_full.tf.erb
@@ -1,0 +1,15 @@
+resource "google_firebase_hosting_site" "default" {
+  provider = google-beta
+  project  = "<%= ctx[:test_env_vars]['project_id'] %>"
+  site_id = "<%= ctx[:vars]['site_id'] %>"
+}
+
+resource "google_firebase_hosting_site_config" "full" {
+  provider = google-beta
+  project  = "<%= ctx[:test_env_vars]['project_id'] %>"
+  site_id = "<%= ctx[:vars]['site_id'] %>"
+  max_versions = 100
+  cloud_logging_enabled = true
+
+  depends_on = [google_firebase_hosting_site.default]
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
